### PR TITLE
Fixing the UBSan warnings

### DIFF
--- a/v3/impl.h
+++ b/v3/impl.h
@@ -5,6 +5,7 @@
 #include <array>
 #include <cstring>
 #include <cfloat>
+#include <limits>
 
 namespace std {
 #define CT(x)                                                                      \
@@ -214,6 +215,7 @@ struct wide_integer<Bits, Signed>::_impl {
     constexpr static void wide_integer_from_bultin(wide_integer<Bits, Signed>& self, double rhs) noexcept {
         constexpr uint64_t max_uint = std::numeric_limits<uint64_t>::max();
         constexpr int64_t max_int = std::numeric_limits<int64_t>::max();
+        constexpr size_t max_sizet = std::numeric_limits<size_t>::max();
 
         if ((rhs > 0 && rhs < max_uint) ||
             (rhs < 0 && rhs > std::numeric_limits<int64_t>::min())) {
@@ -226,7 +228,13 @@ struct wide_integer<Bits, Signed>::_impl {
             r = -r;
         }
 
-        size_t count = r / max_uint;
+        const long double div = r / max_int;
+        size_t count = max_sizet;
+
+        /// r / max_uint may not fit in size_t
+        if (div <= static_cast<long double>(max_sizet))
+            count = div;
+
         self = count;
         self *= max_uint;
         long double to_diff = count;

--- a/v3/impl.h
+++ b/v3/impl.h
@@ -227,14 +227,11 @@ struct wide_integer<Bits, Signed>::_impl {
         const T alpha = t / max_int;
 
         if (alpha <= max_int)
-            for (uint64_t i = 0; i < static_cast<uint64_t>(alpha); ++i)
-                self *= max_int;
-        else
-        {   // max(double) / 2^64 will surely contain less than 52 precision bits, so speed up computations.
+            self = static_cast<uint64_t>(alpha);
+        else // max(double) / 2^64 will surely contain less than 52 precision bits, so speed up computations.
             set_multiplier<double>(self, alpha);
-            self *= max_int;
-        };
 
+        self *= max_int;
         self += static_cast<uint64_t>(t - alpha * max_int); // += b_i
     }
 
@@ -262,7 +259,6 @@ struct wide_integer<Bits, Signed>::_impl {
             ? -static_cast<long double>(rhs)
             : rhs;
 
-        self = (rhs_long_double / max_int > 0) ? 1 : 0;
         set_multiplier(self, rhs_long_double);
 
         if (rhs < 0)


### PR DESCRIPTION
Building this library with UBSan results in a bug:

```
impl.h:188:41: runtime error: 9.22337e+18 is outside the range of representable values of
type 'long'
```

The reason is that some double values may not fit in int64, although the initial values could.
See also https://stackoverflow.com/questions/61877751/outside-the-range-of-representable-values-when-casting-double-to-long-long-with

One possible solution here is to explicilty check for the values using compiler-provided __int128 and, if found overflow, explicitly add the non-overflowing parts.